### PR TITLE
Add model configuration via YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Email Phishing Detector is a tool designed to detect phishing emails by analyzin
 ## ✨ What's new in 1.3.0
 
 - Full refactoring of `phishing_agent.py`.
-- **Basic Mode**: now uses an ensemble of 3 AI models:
+- **Basic Mode**: loads an ensemble of models from `models.yaml` (default set below):
   - `mrm8488/bert-tiny-finetuned-sms-spam-detection`
   - `bhadresh-savani/bert-base-go-emotion`
   - `j-hartmann/emotion-english-distilroberta-base`
@@ -42,13 +42,26 @@ Email Phishing Detector is a tool designed to detect phishing emails by analyzin
 
 ---
 
-## 🧠 AI Model Used
+## 🧠 AI Models
 
-- **Model**: [`mrm8488/bert-tiny-finetuned-sms-spam-detection`](https://huggingface.co/mrm8488/bert-tiny-finetuned-sms-spam-detection)
-- **Purpose**: Spam/phishing vs. ham (binary classification)
-- **Highlights**:
-  - Lightweight & fast (BERT Tiny)
-  - Works locally on CPU
+The agent loads one or more models defined in `models.yaml`. By default it uses:
+- `mrm8488/bert-tiny-finetuned-sms-spam-detection`
+- `bhadresh-savani/bert-base-go-emotion`
+- `j-hartmann/emotion-english-distilroberta-base`
+
+### Adding or replacing models
+
+Edit `models.yaml` to customize the ensemble. Each entry requires an `id` and a
+`label`. For example, you can replace a model with multilingual support using
+`xlm-roberta-base`:
+
+```yaml
+models:
+  - id: xlm-roberta-base
+    label: XLM-RoBERTa
+```
+
+The agent will load the updated list at the next run.
 
 ---
 

--- a/models.yaml
+++ b/models.yaml
@@ -1,0 +1,7 @@
+models:
+  - id: mrm8488/bert-tiny-finetuned-sms-spam-detection
+    label: BERT Tiny
+  - id: bhadresh-savani/bert-base-go-emotion
+    label: Emotion Proxy
+  - id: j-hartmann/emotion-english-distilroberta-base
+    label: Hartmann Emotion

--- a/phishing_agent.py
+++ b/phishing_agent.py
@@ -6,6 +6,7 @@ import sys
 import io
 import traceback
 import contextlib
+import yaml
 import requests
 from bs4 import BeautifulSoup
 from transformers import pipeline, AutoTokenizer, AutoModelForSequenceClassification
@@ -116,11 +117,25 @@ try:
 
     combined_text = f"{subject}\n{clean_body}"
 
-    models = [
+    CONFIG_FILE = "models.yaml"
+    default_models = [
         ("mrm8488/bert-tiny-finetuned-sms-spam-detection", "BERT Tiny"),
         ("bhadresh-savani/bert-base-go-emotion", "Emotion Proxy"),
         ("j-hartmann/emotion-english-distilroberta-base", "Hartmann Emotion")
     ]
+
+    try:
+        with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        models = [
+            (m.get("id"), m.get("label", m.get("id")))
+            for m in data.get("models", [])
+            if m.get("id")
+        ]
+        if not models:
+            models = default_models
+    except Exception:
+        models = default_models
 
     scores = []
     labels = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ python-dotenv
 requests
 fuzzywuzzy
 extract-msg
+pyyaml
 torch
 scikit-learn
 


### PR DESCRIPTION
## Summary
- add `models.yaml` with default model list
- support loading models from YAML in `phishing_agent.py`
- document configurable models and usage in README
- add `pyyaml` to requirements

## Testing
- `pytest -q`